### PR TITLE
Add a variable that helps determine the font file directories

### DIFF
--- a/material-ui/_scaffolding.scss
+++ b/material-ui/_scaffolding.scss
@@ -3,6 +3,7 @@
 @import "variables/media-queries";
 @import "variables/spacing";
 @import "variables/custom-variables";
+@import "variables/icons";
 
 @import "mixins/mixins";
 

--- a/material-ui/material-design-fonticons/_mdfi.scss
+++ b/material-ui/material-design-fonticons/_mdfi.scss
@@ -1,6 +1,6 @@
 @font-face {
   font-family: 'mdfonticon';
-  src: url('fonts/mdfonticon.eot');
+  src: url($mdfi-font-path + 'fonts/mdfonticon.eot');
 }
 @font-face {
   font-family: 'mdfonticon';

--- a/material-ui/material-ui-icons/_style.scss
+++ b/material-ui/material-ui-icons/_style.scss
@@ -1,6 +1,6 @@
 @font-face {
   font-family: 'material-ui-icons';
-  src: url('fonts/material-ui-icons.eot');
+  src: url($mui-icons-font-path + 'fonts/material-ui-icons.eot');
 }
 @font-face {
   font-family: 'material-ui-icons';

--- a/material-ui/variables/_icons.scss
+++ b/material-ui/variables/_icons.scss
@@ -1,0 +1,9 @@
+// The font paths are set here. In case they live elsewhere, a different
+// path must be specified.
+$mui-fonts-path: './' !default;
+
+// Assuming './material-design-fonticons' as base dir.
+$mdfi-font-path: $mui-fonts-path !default;
+
+// Assuming './material-ui-icons' as base dir.
+$mui-icons-font-path: $mui-fonts-path !default;


### PR DESCRIPTION
These variables will default to `./`, but can be easily overridden. This will allow me to use Webpack to easily pack the Sass and all associated fonts.