### PR TITLE
Move keyframe code out of selector context for Libsass compatibility

### DIFF
--- a/material-ui/components/_icon-button.scss
+++ b/material-ui/components/_icon-button.scss
@@ -1,5 +1,7 @@
 $icon-button-size: ($icon-size * 2);
 
+@include pulsate("icon-button-focus-ripple-pulsate");
+
 .mui-icon-button {
 
   * { @include ease-out(); }
@@ -8,11 +10,11 @@ $icon-button-size: ($icon-size * 2);
 
   .mui-focus-ripple {
     .mui-focus-ripple-inner {
+      @include pulsate-animation("icon-button-focus-ripple-pulsate");
       background-color: rgba(0,0,0,0.1);
       box-shadow: 0px 0px 0px 1px rgba(0,0,0,0.1);
       border: solid 6px $transparent;
       background-clip: padding-box;
-      @include pulsate("icon-button-focus-ripple-pulsate");
     }
   }
 

--- a/material-ui/components/_menu.scss
+++ b/material-ui/components/_menu.scss
@@ -1,3 +1,5 @@
+@include ripple-click-alt("menu-item-ripple-animation", darken($white, 20%), 250px);
+
 .mui-menu {
 
   * {@include ease-out(); }
@@ -56,7 +58,7 @@
 
     .mui-ripple {
       &.mui-show {
-        @include ripple-click-alt("menu-item-ripple-animation", darken($white, 20%), 250px);
+        @include ripple-click-alt-animation("menu-item-ripple-animation");
       }
     }
 

--- a/material-ui/components/ripples/_focus-ripple.scss
+++ b/material-ui/components/ripples/_focus-ripple.scss
@@ -1,3 +1,9 @@
+@include pulsate(
+  $animation-name: "focus-ripple-pulsate",
+  $start-size: 0.75,
+  $end-size: 0.85
+);
+
 .mui-focus-ripple {
   position: absolute;
   height: 100%;
@@ -10,18 +16,12 @@
   opacity: 0;
 
   .mui-focus-ripple-inner {
+    @include pulsate-animation("focus-ripple-pulsate");
     position: absolute;
     height: 100%;
     width: 100%;
     border-radius: 50%;
     background-color: rgba(0,0,0,0.1);
-
-    @include pulsate(
-      $animation-name: "focus-ripple-pulsate",
-      $start-size: 0.75,
-      $end-size: 0.85
-    );
-
   }
 
   &.mui-is-shown {

--- a/material-ui/mixins/_ripple.scss
+++ b/material-ui/mixins/_ripple.scss
@@ -1,30 +1,33 @@
 
 
-@mixin ripple-click($animation-name, $color, $size: 150px, $duration: 0.7s) {
-  height: $size;
-  width: $size;
-  margin-top: (-1 * $size / 2);
-  margin-left: (-1 * $size / 2);
-
+@mixin ripple-click($animation-name, $color) {
   @keyframes #{$animation-name} {
     0% { transform: scale(0); background-color: $transparent; }
     50% { background-color: $color; }
     100% { transform: scale(1); background-color: $transparent; }
   }
+}
+
+@mixin ripple-click-animation($animation-name, $size: 150px, $duration: 0.7s) {
+  height: $size;
+  width: $size;
+  margin-top: (-1 * $size / 2);
+  margin-left: (-1 * $size / 2);
   animation: $animation-name $duration;
 }
 
 // Animating using scale transforms causes ripple to ignore border radius 
 // overflow hidden so animate using width instead
-@mixin ripple-click-alt($animation-name, $color, $size: 150px, $duration: 0.7s) {
-
+@mixin ripple-click-alt($animation-name, $color, $size: 150px) {
   @keyframes #{$animation-name} {
     0% {background-color: $transparent; }
     50% { background-color: $color; }
     100% { width: $size; height: $size; background-color: $transparent; }
   }
-  animation: $animation-name $duration;
+}
 
+@mixin ripple-click-alt-animation($animation-name, $duration: 0.7s) {
+  animation: $animation-name $duration;
 }
 
 @mixin ripple-button-focus() {
@@ -37,9 +40,7 @@
   padding-bottom: 100%;
   padding-top: ($desktop-gutter-less * 2);
 
-  @include pulsate(
-    $animation-name: "ripple-button-focus",
-    $start-size: 0.75,
-    $end-size: 0.85
+  @include pulsate-animation(
+    $animation-name: "ripple-button-focus"
   );
 }

--- a/material-ui/mixins/_transitions.scss
+++ b/material-ui/mixins/_transitions.scss
@@ -4,14 +4,14 @@ $ease-out-function: cubic-bezier(0.23, 1, 0.32, 1);
   transition: $property $duration $ease-out-function $delay;
 }
 
-@mixin pulsate($animation-name, $start-size: 0.75, $end-size: 1, $duration: 1.5s) {
-
+@mixin pulsate($animation-name, $start-size: 0.75, $end-size: 1) {
   @keyframes #{$animation-name} {
     0%   { transform: scale($start-size); }
     50%  { transform: scale($end-size);   }
     100% { transform: scale($start-size); }
   }
+}
 
+@mixin pulsate-animation($animation-name, $duration: 1.5s) {
   animation: $animation-name $duration infinite;
-
 }


### PR DESCRIPTION
The keyframes used for the `pulsate` etc. animations are currently included inside of a selector context. Ruby Sass simply moves them outside on compile, but Libsass doesn't, resulting in invalid CSS. This splits up the `@keyframes` and `animation` parts of those mixins so that one can be used outside of selector context and the other inside, producing a valid build.