### PR TITLE
Fix IconButton element's size and positioning inside of Toolbar/ToolbarG...

### DIFF
--- a/material-ui/components/_toolbar.scss
+++ b/material-ui/components/_toolbar.scss
@@ -63,6 +63,15 @@
       }
     }
 
+    .mui-icon-button {
+      margin-top: ($toolbar-height - $icon-size * 2) / 2;
+
+      .mui-icon {
+        line-height: 1;
+        padding-left: 0;
+      }
+    }
+
     &.mui-left {
       float: left;
 


### PR DESCRIPTION
An IconButton element was positioned incorrectly when placed inside of a ToolbarGroup. This changes its positioning and padding so that it looks consistent with Icon elements.